### PR TITLE
Make Balance not transferable

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -240,7 +240,7 @@ pub mod pallet {
 		/// The id type for named reserves.
 		type ReserveIdentifier: Parameter + Member + MaxEncodedLen + Ord + Copy;
 
-		type Transferable: bool;
+		type IsTransferable: bool;
 	}
 
 	#[pallet::pallet]
@@ -487,6 +487,8 @@ pub mod pallet {
 		DeadAccount,
 		/// Number of named reserves exceed MaxReserves
 		TooManyReserves,
+		/// Whether transfer function is allowed or not
+		CannotTransfer,
 	}
 
 	/// The total units issued in the system.
@@ -1482,7 +1484,9 @@ where
 		value: Self::Balance,
 		existence_requirement: ExistenceRequirement,
 	) -> DispatchResult {
-		if value.is_zero() || transactor == dest || T::Transferable == false {
+		ensure!(T::IsTransferable, Error::<T, I>::CannotTransfer);
+
+		if value.is_zero() || transactor == dest {
 			return Ok(())
 		}
 

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -239,6 +239,8 @@ pub mod pallet {
 
 		/// The id type for named reserves.
 		type ReserveIdentifier: Parameter + Member + MaxEncodedLen + Ord + Copy;
+
+		type Transferable: bool;
 	}
 
 	#[pallet::pallet]
@@ -1472,14 +1474,15 @@ where
 	}
 
 	// Transfer some free balance from `transactor` to `dest`, respecting existence requirements.
-	// Is a no-op if value to be transferred is zero or the `transactor` is the same as `dest`.
+	// Is a no-op if value to be transferred is zero or the `transactor` is the same as `dest` or the 
+	// transferability set in config is forbidden.
 	fn transfer(
 		transactor: &T::AccountId,
 		dest: &T::AccountId,
 		value: Self::Balance,
 		existence_requirement: ExistenceRequirement,
 	) -> DispatchResult {
-		if value.is_zero() || transactor == dest {
+		if value.is_zero() || transactor == dest || T::Transferable == false {
 			return Ok(())
 		}
 

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -240,7 +240,7 @@ pub mod pallet {
 		/// The id type for named reserves.
 		type ReserveIdentifier: Parameter + Member + MaxEncodedLen + Ord + Copy;
 
-		type IsTransferable: bool;
+		type IsTransferable: Get<bool>;
 	}
 
 	#[pallet::pallet]
@@ -1484,7 +1484,7 @@ where
 		value: Self::Balance,
 		existence_requirement: ExistenceRequirement,
 	) -> DispatchResult {
-		ensure!(T::IsTransferable, Error::<T, I>::CannotTransfer);
+		ensure!(T::IsTransferable::get(), Error::<T, I>::CannotTransfer);
 
 		if value.is_zero() || transactor == dest {
 			return Ok(())

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -48,6 +48,7 @@ parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
 		frame_system::limits::BlockWeights::simple_max(1024);
 	pub static ExistentialDeposit: u64 = 0;
+	pub static IsTransferable = true;
 }
 impl frame_system::Config for Test {
 	type BaseCallFilter = frame_support::traits::Everything;
@@ -95,6 +96,7 @@ impl Config for Test {
 	type MaxReserves = ConstU32<2>;
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
+	type IsTransferable = IsTransferable;
 }
 
 pub struct ExtBuilder {

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -48,7 +48,7 @@ parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
 		frame_system::limits::BlockWeights::simple_max(1024);
 	pub static ExistentialDeposit: u64 = 0;
-	pub static IsTransferable = true;
+	pub static IsTransferable: bool = true;
 }
 impl frame_system::Config for Test {
 	type BaseCallFilter = frame_support::traits::Everything;

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -97,6 +97,7 @@ impl Config for Test {
 	type MaxReserves = ConstU32<2>;
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
+	type Transferable = bool;
 }
 
 pub struct ExtBuilder {

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -49,7 +49,7 @@ parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
 		frame_system::limits::BlockWeights::simple_max(1024);
 	pub static ExistentialDeposit: u64 = 0;
-	pub static IsTransferable = true;
+	pub static IsTransferable: bool = true;
 }
 impl frame_system::Config for Test {
 	type BaseCallFilter = frame_support::traits::Everything;

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -49,6 +49,7 @@ parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
 		frame_system::limits::BlockWeights::simple_max(1024);
 	pub static ExistentialDeposit: u64 = 0;
+	pub static IsTransferable = true;
 }
 impl frame_system::Config for Test {
 	type BaseCallFilter = frame_support::traits::Everything;
@@ -97,7 +98,7 @@ impl Config for Test {
 	type MaxReserves = ConstU32<2>;
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
-	type Transferable = bool;
+	type Transferable = IsTransferable;
 }
 
 pub struct ExtBuilder {

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -53,6 +53,7 @@ parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
 		frame_system::limits::BlockWeights::simple_max(1024);
 	pub static ExistentialDeposit: u64 = 0;
+	pub static IsTransferable = true;
 }
 impl frame_system::Config for Test {
 	type BaseCallFilter = frame_support::traits::Everything;
@@ -99,6 +100,7 @@ impl Config for Test {
 	type MaxReserves = ConstU32<2>;
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
+	type IsTransferable = IsTransferable;
 }
 
 pub struct ExtBuilder {

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -53,7 +53,7 @@ parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
 		frame_system::limits::BlockWeights::simple_max(1024);
 	pub static ExistentialDeposit: u64 = 0;
-	pub static IsTransferable = true;
+	pub static IsTransferable: bool = true;
 }
 impl frame_system::Config for Test {
 	type BaseCallFilter = frame_support::traits::Everything;


### PR DESCRIPTION
The name of the error `CannotTransfer` is equal to our custom error in `pallet-assets`.