### PR TITLE
Implement do_transfer in pallet-balances

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1204,6 +1204,7 @@ impl<T: Config<I>, I: 'static> fungible::Transfer<T::AccountId> for Pallet<T, I>
 		amount: T::Balance,
 		keep_alive: bool,
 	) -> Result<T::Balance, DispatchError> {
+		ensure!(T::IsTransferable::get(), Error::<T, I>::CannotTransfer);
 		let existence_requirement = if keep_alive { KeepAlive } else { AllowDeath };
 		Self::do_transfer(source, dest, amount, existence_requirement).map(|_| amount)
 	}

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1550,62 +1550,7 @@ where
 		existence_requirement: ExistenceRequirement,
 	) -> DispatchResult {
 		ensure!(T::IsTransferable::get(), Error::<T, I>::CannotTransfer);
-
-		if value.is_zero() || transactor == dest {
-			return Ok(())
-		}
-
-		Self::try_mutate_account_with_dust(
-			dest,
-			|to_account, _| -> Result<DustCleaner<T, I>, DispatchError> {
-				Self::try_mutate_account_with_dust(
-					transactor,
-					|from_account, _| -> DispatchResult {
-						from_account.free = from_account
-							.free
-							.checked_sub(&value)
-							.ok_or(Error::<T, I>::InsufficientBalance)?;
-
-						// NOTE: total stake being stored in the same type means that this could
-						// never overflow but better to be safe than sorry.
-						to_account.free =
-							to_account.free.checked_add(&value).ok_or(ArithmeticError::Overflow)?;
-
-						let ed = T::ExistentialDeposit::get();
-						ensure!(to_account.total() >= ed, Error::<T, I>::ExistentialDeposit);
-
-						Self::ensure_can_withdraw(
-							transactor,
-							value,
-							WithdrawReasons::TRANSFER,
-							from_account.free,
-						)
-						.map_err(|_| Error::<T, I>::LiquidityRestrictions)?;
-
-						// TODO: This is over-conservative. There may now be other providers, and
-						// this pallet may not even be a provider.
-						let allow_death = existence_requirement == ExistenceRequirement::AllowDeath;
-						let allow_death =
-							allow_death && system::Pallet::<T>::can_dec_provider(transactor);
-						ensure!(
-							allow_death || from_account.total() >= ed,
-							Error::<T, I>::KeepAlive
-						);
-
-						Ok(())
-					},
-				)
-				.map(|(_, maybe_dust_cleaner)| maybe_dust_cleaner)
-			},
-		)?;
-
-		// Emit transfer event.
-		Self::deposit_event(Event::Transfer {
-			from: transactor.clone(),
-			to: dest.clone(),
-			amount: value,
-		});
-
+		Self::do_transfer(transactor, dest, value, existence_requirement)?;
 		Ok(())
 	}
 

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1057,7 +1057,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(actual)
 	}
 
-	fn do_transfer(
+	pub fn do_transfer(
 		transactor: &T::AccountId,
 		dest: &T::AccountId,
 		value: T::Balance,
@@ -1541,7 +1541,7 @@ where
 	}
 
 	// Transfer some free balance from `transactor` to `dest`, respecting existence requirements.
-	// Is a no-op if value to be transferred is zero or the `transactor` is the same as `dest` or the 
+	// Is a no-op if value to be transferred is zero or the `transactor` is the same as `dest` or the
 	// transferability set in config is forbidden.
 	fn transfer(
 		transactor: &T::AccountId,
@@ -1550,8 +1550,7 @@ where
 		existence_requirement: ExistenceRequirement,
 	) -> DispatchResult {
 		ensure!(T::IsTransferable::get(), Error::<T, I>::CannotTransfer);
-		let _ = Self::do_transfer(transactor, dest, value, existence_requirement);
-		Ok(())
+		Self::do_transfer(transactor, dest, value, existence_requirement)
 	}
 
 	/// Slash a target account `who`, returning the negative imbalance created and any left over

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1550,8 +1550,7 @@ where
 		existence_requirement: ExistenceRequirement,
 	) -> DispatchResult {
 		ensure!(T::IsTransferable::get(), Error::<T, I>::CannotTransfer);
-		let _ = Self::do_transfer(transactor, dest, value, existence_requirement);
-		Ok(())
+		Self::do_transfer(transactor, dest, value, existence_requirement)
 	}
 
 	/// Slash a target account `who`, returning the negative imbalance created and any left over

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1550,7 +1550,8 @@ where
 		existence_requirement: ExistenceRequirement,
 	) -> DispatchResult {
 		ensure!(T::IsTransferable::get(), Error::<T, I>::CannotTransfer);
-		Self::do_transfer(transactor, dest, value, existence_requirement)
+		Self::do_transfer(transactor, dest, value, existence_requirement)?;
+		Ok(())
 	}
 
 	/// Slash a target account `who`, returning the negative imbalance created and any left over

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1550,7 +1550,7 @@ where
 		existence_requirement: ExistenceRequirement,
 	) -> DispatchResult {
 		ensure!(T::IsTransferable::get(), Error::<T, I>::CannotTransfer);
-		Self::do_transfer(transactor, dest, value, existence_requirement)?;
+		let _ = Self::do_transfer(transactor, dest, value, existence_requirement);
 		Ok(())
 	}
 

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1056,6 +1056,71 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		});
 		Ok(actual)
 	}
+
+	fn do_transfer(
+		transactor: &T::AccountId,
+		dest: &T::AccountId,
+		value: T::Balance,
+		existence_requirement: ExistenceRequirement,
+	) -> Result<T::Balance, DispatchError>  {
+		if value.is_zero() || transactor == dest {
+			return Ok(value)
+		}
+
+		Self::try_mutate_account_with_dust(
+			dest,
+			|to_account, _| -> Result<DustCleaner<T, I>, DispatchError> {
+				Self::try_mutate_account_with_dust(
+					transactor,
+					|from_account, _| -> DispatchResult {
+						from_account.free = from_account
+							.free
+							.checked_sub(&value)
+							.ok_or(Error::<T, I>::InsufficientBalance)?;
+
+						// NOTE: total stake being stored in the same type means that this could
+						// never overflow but better to be safe than sorry.
+						to_account.free =
+							to_account.free.checked_add(&value).ok_or(ArithmeticError::Overflow)?;
+
+						let ed = T::ExistentialDeposit::get();
+						ensure!(to_account.total() >= ed, Error::<T, I>::ExistentialDeposit);
+
+						Self::ensure_can_withdraw(
+							transactor,
+							value,
+							WithdrawReasons::TRANSFER,
+							from_account.free,
+						)
+						.map_err(|_| Error::<T, I>::LiquidityRestrictions)?;
+
+						// TODO: This is over-conservative. There may now be other providers, and
+						// this pallet may not even be a provider.
+						let allow_death = existence_requirement == ExistenceRequirement::AllowDeath;
+						let allow_death =
+							allow_death && system::Pallet::<T>::can_dec_provider(transactor);
+						ensure!(
+							allow_death || from_account.total() >= ed,
+							Error::<T, I>::KeepAlive
+						);
+
+						Ok(())
+					},
+				)
+				.map(|(_, maybe_dust_cleaner)| maybe_dust_cleaner)
+			},
+		)?;
+
+		// Emit transfer event.
+		Self::deposit_event(Event::Transfer {
+			from: transactor.clone(),
+			to: dest.clone(),
+			amount: value,
+		});
+
+		Ok(value)
+	}
+
 }
 
 impl<T: Config<I>, I: 'static> fungible::Inspect<T::AccountId> for Pallet<T, I> {
@@ -1139,8 +1204,8 @@ impl<T: Config<I>, I: 'static> fungible::Transfer<T::AccountId> for Pallet<T, I>
 		amount: T::Balance,
 		keep_alive: bool,
 	) -> Result<T::Balance, DispatchError> {
-		let er = if keep_alive { KeepAlive } else { AllowDeath };
-		<Self as Currency<T::AccountId>>::transfer(source, dest, amount, er).map(|_| amount)
+		let existence_requirement = if keep_alive { KeepAlive } else { AllowDeath };
+		Self::do_transfer(source, dest, amount, existence_requirement).map(|_| amount)
 	}
 }
 


### PR DESCRIPTION
PR related to issue [#151](https://github.com/fragcolor-xyz/clamor/issues/151) in Clamor.

This PR implements this gives an alternative implementation of `transfer` that can be used by `pallet-fragments`, since `transfer` on `Currency` is now blocked.