### PR TITLE
Expose do_mint so it can be used directly from Clamor to mint Tickets

### DIFF
--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -344,7 +344,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// This alters the registered supply of the asset and emits an event.
 	///
 	/// Will return an error or will increase the amount by exactly `amount`.
-	pub(super) fn do_mint(
+	pub fn do_mint(
 		id: T::AssetId,
 		beneficiary: &T::AccountId,
 		amount: T::Balance,


### PR DESCRIPTION
In order to mint Tickets in Clamor, I need this function to be public so that I can call it from an offchain worker (`internal_lock_update` function, when the Ethereum account is _linked_)